### PR TITLE
Make EventLogWalker extendable

### DIFF
--- a/Emmersion.EventLogWalker.UnitTests/EventLogWalkerStatusTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventLogWalkerStatusTests.cs
@@ -24,10 +24,10 @@ namespace Emmersion.EventLogWalker.UnitTests
         {
             var walkState = new WalkState
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -53,10 +53,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var walkState = new WalkState
             {
                 PageEventIndex = 0,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -70,11 +70,11 @@ namespace Emmersion.EventLogWalker.UnitTests
             var walkState = new WalkState
             {
                 PageEventIndex = 2,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -88,11 +88,11 @@ namespace Emmersion.EventLogWalker.UnitTests
             var walkState = new WalkState
             {
                 PageEventIndex = 3,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -106,11 +106,11 @@ namespace Emmersion.EventLogWalker.UnitTests
             var walkState = new WalkState
             {
                 PageEventIndex = 1,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -124,7 +124,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             var walkState = new WalkState
             {
                 PageEventIndex = 0,
-                Events = new List<InsightEvent>()
+                Events = new List<WalkedEvent>()
             };
 
             var status = new EventLogWalkerStatus(walkState, null);

--- a/Emmersion.EventLogWalker.UnitTests/EventLogWalkerStatusTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventLogWalkerStatusTests.cs
@@ -5,148 +5,148 @@ using NUnit.Framework;
 
 namespace Emmersion.EventLogWalker.UnitTests
 {
-    internal class EventLogWalkerStatusTests : With_an_automocked<EventLogWalkerStatus>
+    internal class EventLogWalkerStatusTests : With_an_automocked<EventLogWalkerStatus<InsightEvent>>
     {
         [Test]
         public void When_getting_current_event_index()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 1
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageEventIndex, Is.EqualTo(walkState.PageEventIndex));
         }
 
         [Test]
         public void When_getting_count_of_events_in_page()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
-                Events = new List<WalkedEvent>
+                Events = new List<InsightEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new InsightEvent(),
+                    new InsightEvent()
                 }
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageEventsCount, Is.EqualTo(walkState.Events.Count));
         }
 
         [Test]
         public void When_getting_page_number()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageNumber = 1
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageNumber, Is.EqualTo(walkState.PageNumber));
         }
 
         [Test]
         public void When_the_first_event_of_the_page_is_being_processed()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 0,
-                Events = new List<WalkedEvent>
+                Events = new List<InsightEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new InsightEvent(),
+                    new InsightEvent()
                 }
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageStatus, Is.EqualTo(PageStatus.Start));
         }
 
         [Test]
         public void When_the_last_event_of_the_page_is_being_processed()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 2,
-                Events = new List<WalkedEvent>
+                Events = new List<InsightEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new InsightEvent(),
+                    new InsightEvent(),
+                    new InsightEvent()
                 }
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageStatus, Is.EqualTo(PageStatus.End));
         }
 
         [Test]
         public void When_all_events_for_the_page_have_been_processed()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 3,
-                Events = new List<WalkedEvent>
+                Events = new List<InsightEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new InsightEvent(),
+                    new InsightEvent(),
+                    new InsightEvent()
                 }
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageStatus, Is.EqualTo(PageStatus.Done));
         }
 
         [Test]
         public void When_an_event_of_the_page_is_being_processed_which_is_not_the_first_or_last()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 1,
-                Events = new List<WalkedEvent>
+                Events = new List<InsightEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new InsightEvent(),
+                    new InsightEvent(),
+                    new InsightEvent()
                 }
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageStatus, Is.EqualTo(PageStatus.InProgress));
         }
 
         [Test]
         public void When_the_page_is_empty()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 PageEventIndex = 0,
-                Events = new List<WalkedEvent>()
+                Events = new List<InsightEvent>()
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.PageStatus, Is.EqualTo(PageStatus.Empty));
         }
 
         [Test]
         public void When_getting_total_processed_events()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 TotalEventsProcessed = 5
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.TotalEventsProcessed, Is.EqualTo(walkState.TotalEventsProcessed));
         }
 
         [Test]
         public void When_getting_the_resume_token()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor(),
@@ -162,7 +162,7 @@ namespace Emmersion.EventLogWalker.UnitTests
                 .Callback<ResumeToken>(token => capturedToken = token)
                 .Returns(expectedTokenJson);
 
-            var status = new EventLogWalkerStatus(walkState, jsonSerializerMock.Object);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, jsonSerializerMock.Object);
             var tokenJson = status.GetResumeToken();
 
             Assert.That(tokenJson, Is.EqualTo(expectedTokenJson));
@@ -176,12 +176,12 @@ namespace Emmersion.EventLogWalker.UnitTests
         [Test]
         public void When_getting_the_error_message()
         {
-            var walkState = new WalkState
+            var walkState = new WalkState<InsightEvent>
             {
                 Exception = new Exception(RandomString())
             };
 
-            var status = new EventLogWalkerStatus(walkState, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(walkState, null);
             Assert.That(status.Exception, Is.EqualTo(walkState.Exception));
         }
     }

--- a/Emmersion.EventLogWalker.UnitTests/EventLogWalkerTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventLogWalkerTests.cs
@@ -30,30 +30,30 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialState = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
             var state2 = new WalkState();
             var state3 = new WalkState
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = new Cursor()
             };
             var state4 = new WalkState();
             var finalState = new WalkState
             {
-                Events = new List<InsightEvent>(),
+                Events = new List<WalkedEvent>(),
                 Cursor = null
             };
             var eventProcessorFuncWasCalled = false;
-            Func<InsightEvent, IEventLogWalkerStatus, Task> eventProcessorFunc = (xEvent, xStatus) =>
+            Func<WalkedEvent, IEventLogWalkerStatus, Task> eventProcessorFunc = (xEvent, xStatus) =>
             {
                 eventProcessorFuncWasCalled = true;
                 return Task.CompletedTask;
@@ -100,10 +100,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialState = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
             var state2 = new WalkState
@@ -111,7 +111,7 @@ namespace Emmersion.EventLogWalker.UnitTests
                 Exception = new Exception(RandomString())
             };
             var eventProcessorFuncWasCalled = false;
-            Action<InsightEvent, IEventLogWalkerStatus> eventProcessorFunc = (xEvent, xStatus) =>
+            Action<WalkedEvent, IEventLogWalkerStatus> eventProcessorFunc = (xEvent, xStatus) =>
             {
                 eventProcessorFuncWasCalled = true;
             };
@@ -142,17 +142,17 @@ namespace Emmersion.EventLogWalker.UnitTests
             var resumingInitialState = new WalkState
             {
                 Cursor = null,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
             var state1 = new WalkState();
             var finalState = new WalkState
             {
-                Events = new List<InsightEvent>()
+                Events = new List<WalkedEvent>()
             };
 
             GetMock<IStateLoader>().Setup(x =>
@@ -178,7 +178,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialStateWithError = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>(),
+                Events = new List<WalkedEvent>(),
                 Exception = new Exception(RandomString())
             };
 
@@ -206,10 +206,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialState = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
@@ -244,20 +244,20 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialState = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
             var state2 = new WalkState
             {
                 Cursor = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 

--- a/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
@@ -8,14 +8,14 @@ namespace Emmersion.EventLogWalker.UnitTests
         [Test]
         public async Task When_processing_an_event_async()
         {
-            var insightEvent = new InsightEvent();
+            var insightEvent = new WalkedEvent();
             var status = new EventLogWalkerStatus(null, null);
 
-            InsightEvent capturedInsightEvent = null;
+            WalkedEvent capturedWalkedEvent = null;
             IEventLogWalkerStatus capturedStatus = null;
             var eventProcessor = new EventProcessor((xEvent, xStatus) =>
             {
-                capturedInsightEvent = xEvent;
+                capturedWalkedEvent = xEvent;
                 capturedStatus = xStatus;
 
                 return Task.CompletedTask;
@@ -23,27 +23,27 @@ namespace Emmersion.EventLogWalker.UnitTests
 
             await eventProcessor.ProcessEventAsync(insightEvent, status);
 
-            Assert.That(capturedInsightEvent, Is.SameAs(insightEvent));
+            Assert.That(capturedWalkedEvent, Is.SameAs(insightEvent));
             Assert.That(capturedStatus, Is.SameAs(status));
         }
 
         [Test]
         public async Task When_processing_an_event_synchronous()
         {
-            var insightEvent = new InsightEvent();
+            var insightEvent = new WalkedEvent();
             var status = new EventLogWalkerStatus(null, null);
 
-            InsightEvent capturedInsightEvent = null;
+            WalkedEvent capturedWalkedEvent = null;
             IEventLogWalkerStatus capturedStatus = null;
             var eventProcessor = new EventProcessor((xEvent, xStatus) =>
             {
-                capturedInsightEvent = xEvent;
+                capturedWalkedEvent = xEvent;
                 capturedStatus = xStatus;
             });
 
             await eventProcessor.ProcessEventAsync(insightEvent, status);
 
-            Assert.That(capturedInsightEvent, Is.SameAs(insightEvent));
+            Assert.That(capturedWalkedEvent, Is.SameAs(insightEvent));
             Assert.That(capturedStatus, Is.SameAs(status));
         }
     }

--- a/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
@@ -9,7 +9,7 @@ namespace Emmersion.EventLogWalker.UnitTests
         public async Task When_processing_an_event_async()
         {
             var insightEvent = new InsightEvent();
-            var status = new EventLogWalkerStatus(null, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(null, null);
 
             InsightEvent capturedInsightEvent = null;
             IEventLogWalkerStatus capturedStatus = null;
@@ -31,7 +31,7 @@ namespace Emmersion.EventLogWalker.UnitTests
         public async Task When_processing_an_event_synchronous()
         {
             var insightEvent = new InsightEvent();
-            var status = new EventLogWalkerStatus(null, null);
+            var status = new EventLogWalkerStatus<InsightEvent>(null, null);
 
             InsightEvent capturedInsightEvent = null;
             IEventLogWalkerStatus capturedStatus = null;

--- a/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/EventProcessorTests.cs
@@ -8,14 +8,14 @@ namespace Emmersion.EventLogWalker.UnitTests
         [Test]
         public async Task When_processing_an_event_async()
         {
-            var insightEvent = new WalkedEvent();
+            var insightEvent = new InsightEvent();
             var status = new EventLogWalkerStatus(null, null);
 
-            WalkedEvent capturedWalkedEvent = null;
+            InsightEvent capturedInsightEvent = null;
             IEventLogWalkerStatus capturedStatus = null;
-            var eventProcessor = new EventProcessor((xEvent, xStatus) =>
+            var eventProcessor = new EventProcessor<InsightEvent>((xEvent, xStatus) =>
             {
-                capturedWalkedEvent = xEvent;
+                capturedInsightEvent = xEvent;
                 capturedStatus = xStatus;
 
                 return Task.CompletedTask;
@@ -23,27 +23,27 @@ namespace Emmersion.EventLogWalker.UnitTests
 
             await eventProcessor.ProcessEventAsync(insightEvent, status);
 
-            Assert.That(capturedWalkedEvent, Is.SameAs(insightEvent));
+            Assert.That(capturedInsightEvent, Is.SameAs(insightEvent));
             Assert.That(capturedStatus, Is.SameAs(status));
         }
 
         [Test]
         public async Task When_processing_an_event_synchronous()
         {
-            var insightEvent = new WalkedEvent();
+            var insightEvent = new InsightEvent();
             var status = new EventLogWalkerStatus(null, null);
 
-            WalkedEvent capturedWalkedEvent = null;
+            InsightEvent capturedInsightEvent = null;
             IEventLogWalkerStatus capturedStatus = null;
-            var eventProcessor = new EventProcessor((xEvent, xStatus) =>
+            var eventProcessor = new EventProcessor<InsightEvent>((xEvent, xStatus) =>
             {
-                capturedWalkedEvent = xEvent;
+                capturedInsightEvent = xEvent;
                 capturedStatus = xStatus;
             });
 
             await eventProcessor.ProcessEventAsync(insightEvent, status);
 
-            Assert.That(capturedWalkedEvent, Is.SameAs(insightEvent));
+            Assert.That(capturedInsightEvent, Is.SameAs(insightEvent));
             Assert.That(capturedStatus, Is.SameAs(status));
         }
     }

--- a/Emmersion.EventLogWalker.UnitTests/InsightsSystemApiTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/InsightsSystemApiTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Emmersion.EventLogWalker.Configuration;
 using Emmersion.EventLogWalker.Http;
@@ -8,7 +10,7 @@ using NUnit.Framework;
 
 namespace Emmersion.EventLogWalker.UnitTests
 {
-    internal class InsightsSystemApiTests : With_an_automocked<InsightsSystemApi>
+    internal class InsightsSystemApiTests : With_an_automocked<InsightsSystemApiPager>
     {
         [Test]
         public async Task When_getting_a_page()
@@ -18,7 +20,14 @@ namespace Emmersion.EventLogWalker.UnitTests
             var insightsSystemApiBaseUrl = RandomString();
             var insightsSystemApiApiKey = RandomString();
             var serializedApiPage = RandomString();
-            var expectedPage = new Page();
+            var deserializedApiPage = new InsightsPage
+            {
+                Events = new List<InsightEvent>
+                {
+                    new InsightEvent()
+                },
+                NextPage = new Cursor(),
+            };
 
             HttpRequest capturedHttpRequest = null;
 
@@ -27,7 +36,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             GetMock<IHttpClient>().Setup(x => x.ExecutePostAsync(IsAny<IHttpRequest>()))
                 .Callback<IHttpRequest>(httpRequest => capturedHttpRequest = httpRequest as HttpRequest)
                 .ReturnsAsync(new HttpResponse(200, new HttpHeaders(), serializedApiPage));
-            GetMock<IJsonSerializer>().Setup(x => x.Deserialize<Page>(serializedApiPage)).Returns(expectedPage);
+            GetMock<IJsonSerializer>().Setup(x => x.Deserialize<InsightsPage>(serializedApiPage)).Returns(deserializedApiPage);
             GetMock<IJsonSerializer>().Setup(x => x.Serialize(cursor)).Returns(cursorJson);
 
             var page = await ClassUnderTest.GetPageAsync(cursor);
@@ -39,7 +48,9 @@ namespace Emmersion.EventLogWalker.UnitTests
             Assert.That(capturedHttpRequest.Headers.Exists("Content-Type"), Is.True);
             Assert.That(capturedHttpRequest.Headers.GetValue("Content-Type"), Is.EqualTo("application/json"));
             Assert.That(capturedHttpRequest.Body, Is.EqualTo(cursorJson));
-            Assert.That(page, Is.SameAs(expectedPage));
+            Assert.That(page.Events.Count, Is.EqualTo(deserializedApiPage.Events.Count));
+            Assert.That(page.Events.Single().Event, Is.SameAs(deserializedApiPage.Events.Single()));
+            Assert.That(page.NextPage, Is.SameAs(deserializedApiPage.NextPage));
         }
 
         [Test]

--- a/Emmersion.EventLogWalker.UnitTests/InsightsSystemApiTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/InsightsSystemApiTests.cs
@@ -20,7 +20,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             var insightsSystemApiBaseUrl = RandomString();
             var insightsSystemApiApiKey = RandomString();
             var serializedApiPage = RandomString();
-            var deserializedApiPage = new InsightsPage
+            var deserializedApiPage = new Page<InsightEvent>
             {
                 Events = new List<InsightEvent>
                 {
@@ -36,7 +36,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             GetMock<IHttpClient>().Setup(x => x.ExecutePostAsync(IsAny<IHttpRequest>()))
                 .Callback<IHttpRequest>(httpRequest => capturedHttpRequest = httpRequest as HttpRequest)
                 .ReturnsAsync(new HttpResponse(200, new HttpHeaders(), serializedApiPage));
-            GetMock<IJsonSerializer>().Setup(x => x.Deserialize<InsightsPage>(serializedApiPage)).Returns(deserializedApiPage);
+            GetMock<IJsonSerializer>().Setup(x => x.Deserialize<Page<InsightEvent>>(serializedApiPage)).Returns(deserializedApiPage);
             GetMock<IJsonSerializer>().Setup(x => x.Serialize(cursor)).Returns(cursorJson);
 
             var page = await ClassUnderTest.GetPageAsync(cursor);
@@ -49,7 +49,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             Assert.That(capturedHttpRequest.Headers.GetValue("Content-Type"), Is.EqualTo("application/json"));
             Assert.That(capturedHttpRequest.Body, Is.EqualTo(cursorJson));
             Assert.That(page.Events.Count, Is.EqualTo(deserializedApiPage.Events.Count));
-            Assert.That(page.Events.Single().Event, Is.SameAs(deserializedApiPage.Events.Single()));
+            Assert.That(page.Events.Single(), Is.SameAs(deserializedApiPage.Events.Single()));
             Assert.That(page.NextPage, Is.SameAs(deserializedApiPage.NextPage));
         }
 

--- a/Emmersion.EventLogWalker.UnitTests/StateLoaderTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/StateLoaderTests.cs
@@ -18,15 +18,15 @@ namespace Emmersion.EventLogWalker.UnitTests
             var page = new Page
             {
                 NextPage = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
             Cursor capturedCursor = null;
 
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
+            GetMock<IPager>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
                 .Callback<Cursor>(cursor => capturedCursor = cursor)
                 .ReturnsAsync(page);
 
@@ -58,17 +58,17 @@ namespace Emmersion.EventLogWalker.UnitTests
             var resumeTokenJson = RandomString();
             var page = new Page
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 NextPage = new Cursor()
             };
 
             GetMock<IJsonSerializer>().Setup(x => x.Deserialize<ResumeToken>(resumeTokenJson))
                 .Returns(resumeToken);
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(resumeToken.Cursor))
+            GetMock<IPager>().Setup(x => x.GetPageAsync(resumeToken.Cursor))
                 .ReturnsAsync(page);
 
             var state = await ClassUnderTest.LoadInitialStateAsync(startInclusive, endExclusive, resumeTokenJson);
@@ -97,10 +97,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var resumeTokenJson = RandomString();
             var page = new Page
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 NextPage = new Cursor()
             };
@@ -108,7 +108,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             GetMock<IJsonSerializer>().Setup(x => x.Deserialize<ResumeToken>(resumeTokenJson))
                 .Returns(resumeToken);
             Cursor capturedCursor = null;
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
+            GetMock<IPager>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
                 .Callback<Cursor>(cursor => capturedCursor = cursor)
                 .ReturnsAsync(page);
 
@@ -130,7 +130,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             var start = DateTimeOffset.UtcNow.AddDays(-1);
             var end = DateTimeOffset.UtcNow;
 
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(IsAny<Cursor>())).Throws(exception);
+            GetMock<IPager>().Setup(x => x.GetPageAsync(IsAny<Cursor>())).Throws(exception);
 
             var state = await ClassUnderTest.LoadInitialStateAsync(start, end, null);
 
@@ -161,7 +161,7 @@ namespace Emmersion.EventLogWalker.UnitTests
 
             GetMock<IJsonSerializer>().Setup(x => x.Deserialize<ResumeToken>(resumeTokenJson))
                 .Returns(resumeToken);
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(IsAny<Cursor>())).Throws(exception);
+            GetMock<IPager>().Setup(x => x.GetPageAsync(IsAny<Cursor>())).Throws(exception);
 
             var state = await ClassUnderTest.LoadInitialStateAsync(start, end, resumeTokenJson);
 
@@ -181,10 +181,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             {
                 PageNumber = 1,
                 TotalEventsProcessed = 2,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor()
@@ -192,14 +192,14 @@ namespace Emmersion.EventLogWalker.UnitTests
             var page = new Page
             {
                 NextPage = new Cursor(),
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 }
             };
 
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(previousState.Cursor))
+            GetMock<IPager>().Setup(x => x.GetPageAsync(previousState.Cursor))
                 .ReturnsAsync(page);
 
             var state = await ClassUnderTest.LoadNextStateAsync(previousState);
@@ -219,10 +219,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             {
                 PageNumber = 1,
                 TotalEventsProcessed = 2,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = null,
                 PreviousCursor = new Cursor()
@@ -230,7 +230,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             
             var state = await ClassUnderTest.LoadNextStateAsync(previousState);
 
-            GetMock<IInsightsSystemApi>().VerifyNever(x => x.GetPageAsync(IsAny<Cursor>()));
+            GetMock<IPager>().VerifyNever(x => x.GetPageAsync(IsAny<Cursor>()));
 
             Assert.That(state.Cursor, Is.Null);
             Assert.That(state.PreviousCursor, Is.EqualTo(previousState.PreviousCursor));
@@ -247,17 +247,17 @@ namespace Emmersion.EventLogWalker.UnitTests
             {
                 PageNumber = 1,
                 TotalEventsProcessed = 2,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor()
             };
             var exception = new Exception(RandomString());
 
-            GetMock<IInsightsSystemApi>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
+            GetMock<IPager>().Setup(x => x.GetPageAsync(IsAny<Cursor>()))
                 .Throws(exception);
 
             var state = await ClassUnderTest.LoadNextStateAsync(previousState);

--- a/Emmersion.EventLogWalker.UnitTests/StateProcessorTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/StateProcessorTests.cs
@@ -18,8 +18,8 @@ namespace Emmersion.EventLogWalker.UnitTests
                 PageNumber = pageNumber,
                 Events = new List<WalkedEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new WalkedEvent{ Event = new InsightEvent() },
+                    new WalkedEvent{ Event = new InsightEvent() }
                 },
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor(),
@@ -29,12 +29,12 @@ namespace Emmersion.EventLogWalker.UnitTests
             IEventLogWalkerStatus capturedStatus1 = null;
             IEventLogWalkerStatus capturedStatus2 = null;
 
-            var mockEventProcessor = GetMock<IEventProcessor>();
+            var mockEventProcessor = GetMock<IEventProcessor<InsightEvent>>();
 
-            mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[0], IsAny<IEventLogWalkerStatus>()))
-                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus1 = status);
-            mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[1], IsAny<IEventLogWalkerStatus>()))
-                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus2 = status);
+            mockEventProcessor.Setup(x => x.ProcessEventAsync((InsightEvent)initialState.Events[0].Event, IsAny<IEventLogWalkerStatus>()))
+                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus1 = status);
+            mockEventProcessor.Setup(x => x.ProcessEventAsync((InsightEvent)initialState.Events[1].Event, IsAny<IEventLogWalkerStatus>()))
+                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus2 = status);
 
             var finalState =
                 await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);
@@ -70,8 +70,8 @@ namespace Emmersion.EventLogWalker.UnitTests
             {
                 Events = new List<WalkedEvent>
                 {
-                    new WalkedEvent(),
-                    new WalkedEvent()
+                    new WalkedEvent{ Event = new InsightEvent() },
+                    new WalkedEvent{ Event = new InsightEvent() }
                 },
                 PageNumber = 2,
                 Cursor = new Cursor(),
@@ -81,10 +81,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             };
             IEventLogWalkerStatus capturedStatus = null;
 
-            var mockEventProcessor = GetMock<IEventProcessor>();
+            var mockEventProcessor = GetMock<IEventProcessor<InsightEvent>>();
 
-            mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[1], IsAny<IEventLogWalkerStatus>()))
-                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status);
+            mockEventProcessor.Setup(x => x.ProcessEventAsync((InsightEvent)initialState.Events[1].Event, IsAny<IEventLogWalkerStatus>()))
+                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status);
 
             var finalState =
                 await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);
@@ -116,9 +116,9 @@ namespace Emmersion.EventLogWalker.UnitTests
             };
 
             IEventLogWalkerStatus capturedStatus = null;
-            var mockEventProcessor = GetMock<IEventProcessor>();
-            mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[0], IsAny<IEventLogWalkerStatus>()))
-                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status)
+            var mockEventProcessor = GetMock<IEventProcessor<InsightEvent>>();
+            mockEventProcessor.Setup(x => x.ProcessEventAsync((InsightEvent)initialState.Events[0].Event, IsAny<IEventLogWalkerStatus>()))
+                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status)
                 .Throws(exception);
 
             var finalState = await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);

--- a/Emmersion.EventLogWalker.UnitTests/StateProcessorTests.cs
+++ b/Emmersion.EventLogWalker.UnitTests/StateProcessorTests.cs
@@ -16,10 +16,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var initialState = new WalkState
             {
                 PageNumber = pageNumber,
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor(),
@@ -32,9 +32,9 @@ namespace Emmersion.EventLogWalker.UnitTests
             var mockEventProcessor = GetMock<IEventProcessor>();
 
             mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[0], IsAny<IEventLogWalkerStatus>()))
-                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus1 = status);
+                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus1 = status);
             mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[1], IsAny<IEventLogWalkerStatus>()))
-                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus2 = status);
+                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus2 = status);
 
             var finalState =
                 await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);
@@ -68,10 +68,10 @@ namespace Emmersion.EventLogWalker.UnitTests
         {
             var initialState = new WalkState
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 PageNumber = 2,
                 Cursor = new Cursor(),
@@ -84,7 +84,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             var mockEventProcessor = GetMock<IEventProcessor>();
 
             mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[1], IsAny<IEventLogWalkerStatus>()))
-                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status);
+                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status);
 
             var finalState =
                 await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);
@@ -105,10 +105,10 @@ namespace Emmersion.EventLogWalker.UnitTests
             var exception = new Exception();
             var initialState = new WalkState
             {
-                Events = new List<InsightEvent>
+                Events = new List<WalkedEvent>
                 {
-                    new InsightEvent(),
-                    new InsightEvent()
+                    new WalkedEvent(),
+                    new WalkedEvent()
                 },
                 Cursor = new Cursor(),
                 PreviousCursor = new Cursor(),
@@ -118,7 +118,7 @@ namespace Emmersion.EventLogWalker.UnitTests
             IEventLogWalkerStatus capturedStatus = null;
             var mockEventProcessor = GetMock<IEventProcessor>();
             mockEventProcessor.Setup(x => x.ProcessEventAsync(initialState.Events[0], IsAny<IEventLogWalkerStatus>()))
-                .Callback<InsightEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status)
+                .Callback<WalkedEvent, IEventLogWalkerStatus>((_, status) => capturedStatus = status)
                 .Throws(exception);
 
             var finalState = await ClassUnderTest.ProcessStateAsync(mockEventProcessor.Object, initialState);

--- a/Emmersion.EventLogWalker/Configuration/DependencyInjectionConfig.cs
+++ b/Emmersion.EventLogWalker/Configuration/DependencyInjectionConfig.cs
@@ -19,7 +19,7 @@ namespace Emmersion.EventLogWalker.Configuration
             );
 
             services.AddSingleton<IHttpClient, HttpClient>();
-
+            services.AddTransient<IPager, InsightsSystemApiPager>();
         }
     }
 }

--- a/Emmersion.EventLogWalker/Configuration/DependencyInjectionConfig.cs
+++ b/Emmersion.EventLogWalker/Configuration/DependencyInjectionConfig.cs
@@ -19,7 +19,7 @@ namespace Emmersion.EventLogWalker.Configuration
             );
 
             services.AddSingleton<IHttpClient, HttpClient>();
-            services.AddTransient<IPager, InsightsSystemApiPager>();
+            services.AddTransient<IPager<InsightEvent>, InsightsSystemApiPager>();
         }
     }
 }

--- a/Emmersion.EventLogWalker/EventLogWalker.cs
+++ b/Emmersion.EventLogWalker/EventLogWalker.cs
@@ -6,8 +6,10 @@ namespace Emmersion.EventLogWalker
 {
     public interface IEventLogWalker
     {
-        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<WalkedEvent, IEventLogWalkerStatus, Task> eventProcessor);
-        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<WalkedEvent, IEventLogWalkerStatus> eventProcessor);
+        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
+            where TEvent : class;
+        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
+            where TEvent : class;
     }
 
     internal class EventLogWalker : IEventLogWalker
@@ -26,17 +28,20 @@ namespace Emmersion.EventLogWalker
             resourceThrottle.MinimumDurationBetweenAccess = TimeSpan.FromSeconds(1);
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<WalkedEvent, IEventLogWalkerStatus, Task> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
+            where TEvent : class
         {
-            return WalkAsync(args, new EventProcessor(eventProcessor));
+            return WalkAsync(args, new EventProcessor<TEvent>(eventProcessor));
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<WalkedEvent, IEventLogWalkerStatus> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
+            where TEvent : class
         {
-            return WalkAsync(args, new EventProcessor(eventProcessor));
+            return WalkAsync(args, new EventProcessor<TEvent>(eventProcessor));
         }
 
-        private async Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, IEventProcessor eventProcessor)
+        private async Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs args, IEventProcessor<TEvent> eventProcessor)
+            where TEvent : class
         {
             var state = await stateLoader.LoadInitialStateAsync(args.StartInclusive, args.EndExclusive, args.ResumeToken);
 

--- a/Emmersion.EventLogWalker/EventLogWalker.cs
+++ b/Emmersion.EventLogWalker/EventLogWalker.cs
@@ -6,8 +6,8 @@ namespace Emmersion.EventLogWalker
 {
     public interface IEventLogWalker
     {
-        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<InsightEvent, IEventLogWalkerStatus, Task> eventProcessor);
-        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<InsightEvent, IEventLogWalkerStatus> eventProcessor);
+        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<WalkedEvent, IEventLogWalkerStatus, Task> eventProcessor);
+        Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<WalkedEvent, IEventLogWalkerStatus> eventProcessor);
     }
 
     internal class EventLogWalker : IEventLogWalker
@@ -26,12 +26,12 @@ namespace Emmersion.EventLogWalker
             resourceThrottle.MinimumDurationBetweenAccess = TimeSpan.FromSeconds(1);
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<InsightEvent, IEventLogWalkerStatus, Task> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Func<WalkedEvent, IEventLogWalkerStatus, Task> eventProcessor)
         {
             return WalkAsync(args, new EventProcessor(eventProcessor));
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<InsightEvent, IEventLogWalkerStatus> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync(WalkArgs args, Action<WalkedEvent, IEventLogWalkerStatus> eventProcessor)
         {
             return WalkAsync(args, new EventProcessor(eventProcessor));
         }

--- a/Emmersion.EventLogWalker/EventLogWalker.cs
+++ b/Emmersion.EventLogWalker/EventLogWalker.cs
@@ -6,9 +6,9 @@ namespace Emmersion.EventLogWalker
 {
     public interface IEventLogWalker
     {
-        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs<TEvent> args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
+        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(IPager<TEvent> pager, WalkArgs args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
             where TEvent : class;
-        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs<TEvent> args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
+        Task<IEventLogWalkerStatus> WalkAsync<TEvent>(IPager<TEvent> pager, WalkArgs args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
             where TEvent : class;
     }
 
@@ -28,22 +28,22 @@ namespace Emmersion.EventLogWalker
             resourceThrottle.MinimumDurationBetweenAccess = TimeSpan.FromSeconds(1);
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs<TEvent> args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(IPager<TEvent> pager, WalkArgs args, Func<TEvent, IEventLogWalkerStatus, Task> eventProcessor)
             where TEvent : class
         {
-            return WalkAsync(args, new EventProcessor<TEvent>(eventProcessor));
+            return WalkAsync(pager, args, new EventProcessor<TEvent>(eventProcessor));
         }
 
-        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs<TEvent> args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
+        public Task<IEventLogWalkerStatus> WalkAsync<TEvent>(IPager<TEvent> pager, WalkArgs args, Action<TEvent, IEventLogWalkerStatus> eventProcessor)
             where TEvent : class
         {
-            return WalkAsync(args, new EventProcessor<TEvent>(eventProcessor));
+            return WalkAsync(pager, args, new EventProcessor<TEvent>(eventProcessor));
         }
 
-        private async Task<IEventLogWalkerStatus> WalkAsync<TEvent>(WalkArgs<TEvent> args, IEventProcessor<TEvent> eventProcessor)
+        private async Task<IEventLogWalkerStatus> WalkAsync<TEvent>(IPager<TEvent> pager, WalkArgs args, IEventProcessor<TEvent> eventProcessor)
             where TEvent : class
         {
-            var state = await stateLoader.LoadInitialStateAsync(args.Pager, args.StartInclusive, args.EndExclusive, args.ResumeToken);
+            var state = await stateLoader.LoadInitialStateAsync(pager, args.StartInclusive, args.EndExclusive, args.ResumeToken);
 
             while (state.Events.Any() && state.Exception == null)
             {
@@ -56,17 +56,15 @@ namespace Emmersion.EventLogWalker
                 }
 
                 await resourceThrottle.WaitForNextAccessAsync();
-                state = await stateLoader.LoadNextStateAsync(args.Pager, state);
+                state = await stateLoader.LoadNextStateAsync(pager, state);
             }
 
             return new EventLogWalkerStatus<TEvent>(state, jsonSerializer);
         }
     }
 
-    public class WalkArgs<TEvent>
-        where TEvent : class
+    public class WalkArgs
     {
-        public IPager<TEvent> Pager { get; set; }
         public DateTimeOffset StartInclusive { get; set; } = DateTimeOffset.MinValue;
         public DateTimeOffset EndExclusive { get; set; } = DateTimeOffset.MaxValue;
         public string ResumeToken { get; set; }

--- a/Emmersion.EventLogWalker/EventLogWalkerStatus.cs
+++ b/Emmersion.EventLogWalker/EventLogWalkerStatus.cs
@@ -13,12 +13,13 @@ namespace Emmersion.EventLogWalker
         string GetResumeToken();
     }
 
-    internal class EventLogWalkerStatus : IEventLogWalkerStatus
+    internal class EventLogWalkerStatus<TEvent> : IEventLogWalkerStatus
+        where TEvent : class
     {
-        private readonly WalkState state;
+        private readonly WalkState<TEvent> state;
         private readonly IJsonSerializer jsonSerializer;
 
-        public EventLogWalkerStatus(WalkState state, IJsonSerializer jsonSerializer)
+        public EventLogWalkerStatus(WalkState<TEvent> state, IJsonSerializer jsonSerializer)
         {
             this.state = state;
             this.jsonSerializer = jsonSerializer;

--- a/Emmersion.EventLogWalker/EventProcessor.cs
+++ b/Emmersion.EventLogWalker/EventProcessor.cs
@@ -6,7 +6,7 @@ namespace Emmersion.EventLogWalker
     internal interface IEventProcessor<TEvent>
         where TEvent : class
     {
-        Task ProcessEventAsync(TEvent walkedEvent, IEventLogWalkerStatus status);
+        Task ProcessEventAsync(TEvent @event, IEventLogWalkerStatus status);
     }
 
     internal class EventProcessor<TEvent> : IEventProcessor<TEvent>
@@ -21,16 +21,16 @@ namespace Emmersion.EventLogWalker
 
         public EventProcessor(Action<TEvent, IEventLogWalkerStatus> processorFunc)
         {
-            this.processorFunc = (insightEvent, status) =>
+            this.processorFunc = (@event, status) =>
             {
-                processorFunc(insightEvent, status);
+                processorFunc(@event, status);
                 return Task.CompletedTask;
             };
         }
 
-        public Task ProcessEventAsync(TEvent walkedEvent, IEventLogWalkerStatus status)
+        public Task ProcessEventAsync(TEvent @event, IEventLogWalkerStatus status)
         {
-            return processorFunc(walkedEvent, status);
+            return processorFunc(@event, status);
         }
     }
 }

--- a/Emmersion.EventLogWalker/EventProcessor.cs
+++ b/Emmersion.EventLogWalker/EventProcessor.cs
@@ -5,19 +5,19 @@ namespace Emmersion.EventLogWalker
 {
     internal interface IEventProcessor
     {
-        Task ProcessEventAsync(InsightEvent insightEvent, IEventLogWalkerStatus status);
+        Task ProcessEventAsync(WalkedEvent walkedEvent, IEventLogWalkerStatus status);
     }
 
     internal class EventProcessor : IEventProcessor
     {
-        private readonly Func<InsightEvent, IEventLogWalkerStatus, Task> processorFunc;
+        private readonly Func<WalkedEvent, IEventLogWalkerStatus, Task> processorFunc;
 
-        public EventProcessor(Func<InsightEvent, IEventLogWalkerStatus, Task> processorFunc)
+        public EventProcessor(Func<WalkedEvent, IEventLogWalkerStatus, Task> processorFunc)
         {
             this.processorFunc = processorFunc;
         }
 
-        public EventProcessor(Action<InsightEvent, IEventLogWalkerStatus> processorFunc)
+        public EventProcessor(Action<WalkedEvent, IEventLogWalkerStatus> processorFunc)
         {
             this.processorFunc = (insightEvent, status) =>
             {
@@ -26,9 +26,9 @@ namespace Emmersion.EventLogWalker
             };
         }
 
-        public Task ProcessEventAsync(InsightEvent insightEvent, IEventLogWalkerStatus status)
+        public Task ProcessEventAsync(WalkedEvent walkedEvent, IEventLogWalkerStatus status)
         {
-            return processorFunc(insightEvent, status);
+            return processorFunc(walkedEvent, status);
         }
     }
 }

--- a/Emmersion.EventLogWalker/EventProcessor.cs
+++ b/Emmersion.EventLogWalker/EventProcessor.cs
@@ -3,21 +3,23 @@ using System.Threading.Tasks;
 
 namespace Emmersion.EventLogWalker
 {
-    internal interface IEventProcessor
+    internal interface IEventProcessor<TEvent>
+        where TEvent : class
     {
-        Task ProcessEventAsync(WalkedEvent walkedEvent, IEventLogWalkerStatus status);
+        Task ProcessEventAsync(TEvent walkedEvent, IEventLogWalkerStatus status);
     }
 
-    internal class EventProcessor : IEventProcessor
+    internal class EventProcessor<TEvent> : IEventProcessor<TEvent>
+        where TEvent : class
     {
-        private readonly Func<WalkedEvent, IEventLogWalkerStatus, Task> processorFunc;
+        private readonly Func<TEvent, IEventLogWalkerStatus, Task> processorFunc;
 
-        public EventProcessor(Func<WalkedEvent, IEventLogWalkerStatus, Task> processorFunc)
+        public EventProcessor(Func<TEvent, IEventLogWalkerStatus, Task> processorFunc)
         {
             this.processorFunc = processorFunc;
         }
 
-        public EventProcessor(Action<WalkedEvent, IEventLogWalkerStatus> processorFunc)
+        public EventProcessor(Action<TEvent, IEventLogWalkerStatus> processorFunc)
         {
             this.processorFunc = (insightEvent, status) =>
             {
@@ -26,7 +28,7 @@ namespace Emmersion.EventLogWalker
             };
         }
 
-        public Task ProcessEventAsync(WalkedEvent walkedEvent, IEventLogWalkerStatus status)
+        public Task ProcessEventAsync(TEvent walkedEvent, IEventLogWalkerStatus status)
         {
             return processorFunc(walkedEvent, status);
         }

--- a/Emmersion.EventLogWalker/InsightsSystemApiPager.cs
+++ b/Emmersion.EventLogWalker/InsightsSystemApiPager.cs
@@ -1,23 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Emmersion.EventLogWalker.Configuration;
 using Emmersion.EventLogWalker.Http;
 
 namespace Emmersion.EventLogWalker
 {
-    internal interface IInsightsSystemApi
-    {
-        Task<Page> GetPageAsync(Cursor cursor);
-    }
-
-    internal class InsightsSystemApi : IInsightsSystemApi
+    internal class InsightsSystemApiPager : IPager
     {
         private readonly IHttpClient httpClient;
         private readonly IInsightsSystemApiSettings insightsSystemApiSettings;
         private readonly IJsonSerializer jsonSerializer;
 
-        public InsightsSystemApi(IHttpClient httpClient,
+        public InsightsSystemApiPager(IHttpClient httpClient,
             IInsightsSystemApiSettings insightsSystemApiSettings,
             IJsonSerializer jsonSerializer)
         {
@@ -38,26 +34,39 @@ namespace Emmersion.EventLogWalker
 
             var response = await httpClient.ExecutePostAsync(request);
 
-            return response.StatusCode switch
+            var result = response.StatusCode switch
             {
-                200 => jsonSerializer.Deserialize<Page>(response.Body),
+                200 => jsonSerializer.Deserialize<InsightsPage>(response.Body),
                 403 => throw new Exception(
                     $"Double check your credentials: Got status code {response.StatusCode} when calling {request.Url} with body {request.Body}"),
                 _ => throw new Exception(
                     $"Unexpected status code {response.StatusCode} when calling {request.Url} with body {request.Body}")
             };
+
+            return Map(result);
+        }
+
+        private Page Map(InsightsPage insightsPage)
+        {
+            return new Page
+            {
+                Events = insightsPage.Events.Select(Map).ToList(),
+                NextPage = insightsPage.NextPage
+            };
+        }
+
+        private WalkedEvent Map(InsightEvent insightEvent)
+        {
+            return new WalkedEvent
+            {
+                Event = insightEvent
+            };
         }
     }
 
-    internal class Page
+    internal class InsightsPage
     {
         public List<InsightEvent> Events { get; set; }
         public Cursor NextPage { get; set; }
-    }
-
-    internal class Cursor
-    {
-        public DateTimeOffset StartInclusive { get; set; }
-        public DateTimeOffset EndExclusive { get; set; }
     }
 }

--- a/Emmersion.EventLogWalker/InsightsSystemApiPager.cs
+++ b/Emmersion.EventLogWalker/InsightsSystemApiPager.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Emmersion.EventLogWalker.Configuration;
 using Emmersion.EventLogWalker.Http;
 
 namespace Emmersion.EventLogWalker
 {
-    internal class InsightsSystemApiPager : IPager
+    internal class InsightsSystemApiPager : IPager<InsightEvent>
     {
         private readonly IHttpClient httpClient;
         private readonly IInsightsSystemApiSettings insightsSystemApiSettings;
@@ -22,7 +20,7 @@ namespace Emmersion.EventLogWalker
             this.jsonSerializer = jsonSerializer;
         }
 
-        public async Task<Page> GetPageAsync(Cursor cursor)
+        public async Task<Page<InsightEvent>> GetPageAsync(Cursor cursor)
         {
             var request = new HttpRequest
             {
@@ -36,37 +34,14 @@ namespace Emmersion.EventLogWalker
 
             var result = response.StatusCode switch
             {
-                200 => jsonSerializer.Deserialize<InsightsPage>(response.Body),
+                200 => jsonSerializer.Deserialize<Page<InsightEvent>>(response.Body),
                 403 => throw new Exception(
                     $"Double check your credentials: Got status code {response.StatusCode} when calling {request.Url} with body {request.Body}"),
                 _ => throw new Exception(
                     $"Unexpected status code {response.StatusCode} when calling {request.Url} with body {request.Body}")
             };
 
-            return Map(result);
+            return result;
         }
-
-        private Page Map(InsightsPage insightsPage)
-        {
-            return new Page
-            {
-                Events = insightsPage.Events.Select(Map).ToList(),
-                NextPage = insightsPage.NextPage
-            };
-        }
-
-        private WalkedEvent Map(InsightEvent insightEvent)
-        {
-            return new WalkedEvent
-            {
-                Event = insightEvent
-            };
-        }
-    }
-
-    internal class InsightsPage
-    {
-        public List<InsightEvent> Events { get; set; }
-        public Cursor NextPage { get; set; }
     }
 }

--- a/Emmersion.EventLogWalker/Pager.cs
+++ b/Emmersion.EventLogWalker/Pager.cs
@@ -15,6 +15,11 @@ namespace Emmersion.EventLogWalker
         public Cursor NextPage { get; set; }
     }
 
+    public class WalkedEvent
+    {
+        public object Event { get; set; }
+    }
+
     public class Cursor
     {
         public DateTimeOffset StartInclusive { get; set; }

--- a/Emmersion.EventLogWalker/Pager.cs
+++ b/Emmersion.EventLogWalker/Pager.cs
@@ -4,20 +4,16 @@ using System.Threading.Tasks;
 
 namespace Emmersion.EventLogWalker
 {
-    public interface IPager
+    public interface IPager<TEvent>
+        where TEvent : class
     {
-        Task<Page> GetPageAsync(Cursor cursor);
+        Task<Page<TEvent>> GetPageAsync(Cursor cursor);
     }
 
-    public class Page
+    public class Page<TEvent>
     {
-        public List<WalkedEvent> Events { get; set; }
+        public List<TEvent> Events { get; set; }
         public Cursor NextPage { get; set; }
-    }
-
-    public class WalkedEvent
-    {
-        public object Event { get; set; }
     }
 
     public class Cursor

--- a/Emmersion.EventLogWalker/Pager.cs
+++ b/Emmersion.EventLogWalker/Pager.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Emmersion.EventLogWalker
+{
+    public interface IPager
+    {
+        Task<Page> GetPageAsync(Cursor cursor);
+    }
+
+    public class Page
+    {
+        public List<WalkedEvent> Events { get; set; }
+        public Cursor NextPage { get; set; }
+    }
+
+    public class Cursor
+    {
+        public DateTimeOffset StartInclusive { get; set; }
+        public DateTimeOffset EndExclusive { get; set; }
+    }
+}

--- a/Emmersion.EventLogWalker/StateLoader.cs
+++ b/Emmersion.EventLogWalker/StateLoader.cs
@@ -14,12 +14,12 @@ namespace Emmersion.EventLogWalker
 
     internal class StateLoader : IStateLoader
     {
-        private readonly IInsightsSystemApi insightsSystemApi;
+        private readonly IPager pager;
         private readonly IJsonSerializer jsonSerializer;
 
-        public StateLoader(IInsightsSystemApi insightsSystemApi, IJsonSerializer jsonSerializer)
+        public StateLoader(IPager pager, IJsonSerializer jsonSerializer)
         {
-            this.insightsSystemApi = insightsSystemApi;
+            this.pager = pager;
             this.jsonSerializer = jsonSerializer;
         }
 
@@ -59,7 +59,7 @@ namespace Emmersion.EventLogWalker
                 {
                     Cursor = cursor,
                     PreviousCursor = resumeToken?.Cursor,
-                    Events = new List<InsightEvent>(),
+                    Events = new List<WalkedEvent>(),
                     PageEventIndex = resumeToken?.PageEventIndex ?? 0,
                     PageNumber = resumeToken?.PageNumber ?? 1,
                     TotalEventsProcessed = resumeToken?.TotalProcessedEvents ?? 0,
@@ -78,7 +78,7 @@ namespace Emmersion.EventLogWalker
                     {
                         Cursor = null,
                         PreviousCursor = previousState.PreviousCursor,
-                        Events = new List<InsightEvent>(),
+                        Events = new List<WalkedEvent>(),
                         PageEventIndex = 0,
                         PageNumber = previousState.PageNumber + 1,
                         TotalEventsProcessed = previousState.TotalEventsProcessed
@@ -104,7 +104,7 @@ namespace Emmersion.EventLogWalker
 
         private async Task<WalkState> LoadStateFromPageAsync(WalkState previousState)
         {
-            var page = await insightsSystemApi.GetPageAsync(previousState.Cursor);
+            var page = await pager.GetPageAsync(previousState.Cursor);
 
             return new WalkState
             {

--- a/Emmersion.EventLogWalker/StateLoader.cs
+++ b/Emmersion.EventLogWalker/StateLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Emmersion.EventLogWalker

--- a/Emmersion.EventLogWalker/StateLoader.cs
+++ b/Emmersion.EventLogWalker/StateLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Emmersion.EventLogWalker

--- a/Emmersion.EventLogWalker/StateLoader.cs
+++ b/Emmersion.EventLogWalker/StateLoader.cs
@@ -1,30 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Emmersion.EventLogWalker
 {
     internal interface IStateLoader
     {
-        Task<WalkState> LoadInitialStateAsync(DateTimeOffset startInclusive, DateTimeOffset endExclusive,
-            string resumeTokenJson);
-
-        Task<WalkState> LoadNextStateAsync(WalkState previousState);
+        Task<WalkState<TEvent>> LoadInitialStateAsync<TEvent>(IPager<TEvent> pager, DateTimeOffset startInclusive, DateTimeOffset endExclusive, string resumeTokenJson)
+            where TEvent : class;
+        Task<WalkState<TEvent>> LoadNextStateAsync<TEvent>(IPager<TEvent> pager, WalkState<TEvent> previousState)
+            where TEvent : class;
     }
 
     internal class StateLoader : IStateLoader
     {
-        private readonly IPager pager;
         private readonly IJsonSerializer jsonSerializer;
 
-        public StateLoader(IPager pager, IJsonSerializer jsonSerializer)
+        public StateLoader(IJsonSerializer jsonSerializer)
         {
-            this.pager = pager;
             this.jsonSerializer = jsonSerializer;
         }
 
-        public async Task<WalkState> LoadInitialStateAsync(DateTimeOffset startInclusive, DateTimeOffset endExclusive,
-            string resumeTokenJson)
+        public async Task<WalkState<TEvent>> LoadInitialStateAsync<TEvent>(IPager<TEvent> pager,
+            DateTimeOffset startInclusive, DateTimeOffset endExclusive, string resumeTokenJson)
+            where TEvent : class
         {
             var cursor = new Cursor
             {
@@ -41,9 +41,9 @@ namespace Emmersion.EventLogWalker
                     cursor = resumeToken.Cursor ?? cursor;
                 }
 
-                var initialState = await LoadStateFromPageAsync(new WalkState {Cursor = cursor});
+                var initialState = await LoadStateFromPageAsync(pager, new WalkState<TEvent> {Cursor = cursor});
 
-                return new WalkState
+                return new WalkState<TEvent>
                 {
                     Events = initialState.Events,
                     Cursor = initialState.Cursor,
@@ -55,11 +55,11 @@ namespace Emmersion.EventLogWalker
             }
             catch (Exception exception)
             {
-                return new WalkState
+                return new WalkState<TEvent>
                 {
                     Cursor = cursor,
                     PreviousCursor = resumeToken?.Cursor,
-                    Events = new List<WalkedEvent>(),
+                    Events = new List<TEvent>(),
                     PageEventIndex = resumeToken?.PageEventIndex ?? 0,
                     PageNumber = resumeToken?.PageNumber ?? 1,
                     TotalEventsProcessed = resumeToken?.TotalProcessedEvents ?? 0,
@@ -68,28 +68,29 @@ namespace Emmersion.EventLogWalker
             }
         }
 
-        public async Task<WalkState> LoadNextStateAsync(WalkState previousState)
+        public async Task<WalkState<TEvent>> LoadNextStateAsync<TEvent>(IPager<TEvent> pager, WalkState<TEvent> previousState)
+            where TEvent : class
         {
             try
             {
                 if (previousState.Cursor == null)
                 {
-                    return new WalkState
+                    return new WalkState<TEvent>
                     {
                         Cursor = null,
                         PreviousCursor = previousState.PreviousCursor,
-                        Events = new List<WalkedEvent>(),
+                        Events = new List<TEvent>(),
                         PageEventIndex = 0,
                         PageNumber = previousState.PageNumber + 1,
                         TotalEventsProcessed = previousState.TotalEventsProcessed
                     };
                 }
 
-                return await LoadStateFromPageAsync(previousState);
+                return await LoadStateFromPageAsync(pager, previousState);
             }
             catch (Exception exception)
             {
-                return new WalkState
+                return new WalkState<TEvent>
                 {
                     PageEventIndex = previousState.PageEventIndex,
                     Cursor = previousState.Cursor,
@@ -102,11 +103,12 @@ namespace Emmersion.EventLogWalker
             }
         }
 
-        private async Task<WalkState> LoadStateFromPageAsync(WalkState previousState)
+        private async Task<WalkState<TEvent>> LoadStateFromPageAsync<TEvent>(IPager<TEvent> pager, WalkState<TEvent> previousState)
+            where TEvent : class
         {
             var page = await pager.GetPageAsync(previousState.Cursor);
 
-            return new WalkState
+            return new WalkState<TEvent>
             {
                 Cursor = page.NextPage,
                 PreviousCursor = previousState.Cursor,

--- a/Emmersion.EventLogWalker/StateProcessor.cs
+++ b/Emmersion.EventLogWalker/StateProcessor.cs
@@ -5,7 +5,8 @@ namespace Emmersion.EventLogWalker
 {
     internal interface IStateProcessor
     {
-        Task<WalkState> ProcessStateAsync(IEventProcessor eventProcessor, WalkState state);
+        Task<WalkState> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState state)
+            where TEvent : class;
     }
 
     internal class StateProcessor : IStateProcessor
@@ -17,7 +18,8 @@ namespace Emmersion.EventLogWalker
             this.jsonSerializer = jsonSerializer;
         }
 
-        public async Task<WalkState> ProcessStateAsync(IEventProcessor eventProcessor, WalkState state)
+        public async Task<WalkState> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState state)
+            where TEvent : class
         {
             var processedEvents = 0;
             var walkStateInProgress = state;
@@ -34,7 +36,8 @@ namespace Emmersion.EventLogWalker
                         PageEventIndex = i,
                         TotalEventsProcessed = state.TotalEventsProcessed + processedEvents
                     };
-                    await eventProcessor.ProcessEventAsync(state.Events[i],
+
+                    await eventProcessor.ProcessEventAsync(state.Events[i].Event as TEvent,
                         new EventLogWalkerStatus(walkStateInProgress, jsonSerializer));
                     processedEvents++;
                 }

--- a/Emmersion.EventLogWalker/StateProcessor.cs
+++ b/Emmersion.EventLogWalker/StateProcessor.cs
@@ -5,7 +5,7 @@ namespace Emmersion.EventLogWalker
 {
     internal interface IStateProcessor
     {
-        Task<WalkState> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState state)
+        Task<WalkState<TEvent>> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState<TEvent> state)
             where TEvent : class;
     }
 
@@ -18,7 +18,7 @@ namespace Emmersion.EventLogWalker
             this.jsonSerializer = jsonSerializer;
         }
 
-        public async Task<WalkState> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState state)
+        public async Task<WalkState<TEvent>> ProcessStateAsync<TEvent>(IEventProcessor<TEvent> eventProcessor, WalkState<TEvent> state)
             where TEvent : class
         {
             var processedEvents = 0;
@@ -27,7 +27,7 @@ namespace Emmersion.EventLogWalker
             {
                 try
                 {
-                    walkStateInProgress = new WalkState
+                    walkStateInProgress = new WalkState<TEvent>
                     {
                         Events = state.Events,
                         Cursor = state.Cursor,
@@ -37,13 +37,13 @@ namespace Emmersion.EventLogWalker
                         TotalEventsProcessed = state.TotalEventsProcessed + processedEvents
                     };
 
-                    await eventProcessor.ProcessEventAsync(state.Events[i].Event as TEvent,
-                        new EventLogWalkerStatus(walkStateInProgress, jsonSerializer));
+                    await eventProcessor.ProcessEventAsync(state.Events[i],
+                        new EventLogWalkerStatus<TEvent>(walkStateInProgress, jsonSerializer));
                     processedEvents++;
                 }
                 catch (Exception exception)
                 {
-                    return new WalkState
+                    return new WalkState<TEvent>
                     {
                         Events = walkStateInProgress.Events,
                         Cursor = walkStateInProgress.Cursor,
@@ -56,7 +56,7 @@ namespace Emmersion.EventLogWalker
                 }
             }
 
-            return new WalkState
+            return new WalkState<TEvent>
             {
                 Events = state.Events,
                 Cursor = state.Cursor,

--- a/Emmersion.EventLogWalker/WalkState.cs
+++ b/Emmersion.EventLogWalker/WalkState.cs
@@ -5,7 +5,7 @@ namespace Emmersion.EventLogWalker
 {
     internal class WalkState
     {
-        public List<InsightEvent> Events { get; set; } = new List<InsightEvent>();
+        public List<WalkedEvent> Events { get; set; } = new List<WalkedEvent>();
         public Cursor Cursor { get; set; }
         public Cursor PreviousCursor { get; set; }
         public int PageEventIndex { get; set; }

--- a/Emmersion.EventLogWalker/WalkState.cs
+++ b/Emmersion.EventLogWalker/WalkState.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 
 namespace Emmersion.EventLogWalker
 {
-    internal class WalkState
+    internal class WalkState<TEvent>
+        where TEvent : class
     {
-        public List<WalkedEvent> Events { get; set; } = new List<WalkedEvent>();
+        public List<TEvent> Events { get; set; } = new List<TEvent>();
         public Cursor Cursor { get; set; }
         public Cursor PreviousCursor { get; set; }
         public int PageEventIndex { get; set; }

--- a/Emmersion.EventLogWalker/WalkedEvent.cs
+++ b/Emmersion.EventLogWalker/WalkedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Emmersion.EventLogWalker
+{
+    public class WalkedEvent
+    {
+        public InsightEvent Event { get; set; }
+    }
+}

--- a/Emmersion.EventLogWalker/WalkedEvent.cs
+++ b/Emmersion.EventLogWalker/WalkedEvent.cs
@@ -1,7 +1,0 @@
-﻿namespace Emmersion.EventLogWalker
-{
-    public class WalkedEvent
-    {
-        public InsightEvent Event { get; set; }
-    }
-}

--- a/ExampleReports.UnitTests/AccountUserCountsReportTests.cs
+++ b/ExampleReports.UnitTests/AccountUserCountsReportTests.cs
@@ -56,9 +56,9 @@ namespace ExampleReports.UnitTests
                 });
 
             WalkArgs capturedWalkArgs = null;
-            Action<InsightEvent, IEventLogWalkerStatus> capturedFunc = null;
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
-                .Callback<WalkArgs, Action<InsightEvent, IEventLogWalkerStatus>>((args, func) =>
+            Action<WalkedEvent, IEventLogWalkerStatus> capturedFunc = null;
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<WalkedEvent, IEventLogWalkerStatus>>()))
+                .Callback<WalkArgs, Action<WalkedEvent, IEventLogWalkerStatus>>((args, func) =>
                 {
                     capturedWalkArgs = args;
                     capturedFunc = func;
@@ -72,7 +72,7 @@ namespace ExampleReports.UnitTests
             Assert.That(capturedWalkArgs.StartInclusive, Is.EqualTo(reportPeriodStartInclusive));
             Assert.That(capturedWalkArgs.EndExclusive, Is.EqualTo(reportPeriodEndExclusive));
             Assert.That(capturedWalkArgs.ResumeToken, Is.Null);
-            Assert.That(capturedFunc, Is.EqualTo((Action<InsightEvent, IEventLogWalkerStatus>)ClassUnderTest.ProcessEvent));
+            Assert.That(capturedFunc, Is.EqualTo((Action<WalkedEvent, IEventLogWalkerStatus>)ClassUnderTest.ProcessEvent));
 
             Assert.That(capturedFileName, Is.EqualTo($"{nameof(AccountUserCountsReport)}_(from {reportPeriodStartInclusive:yyyy-MM-dd} to {reportPeriodEndExclusive:yyyy-MM-dd})_{DateTimeOffset.UtcNow:yyyy-MM-dd HH_mm_ss}.csv"));
             Assert.That(capturedHeaderRow, Is.EqualTo($"{nameof(EventCounts.EventType)},{nameof(EventCounts.DistinctAccounts)},{nameof(EventCounts.DistinctUsers)}"));
@@ -103,8 +103,8 @@ namespace ExampleReports.UnitTests
             GetMock<IJsonSerializer>().Setup(x => x.Deserialize<AccountUserCountsReportState>(stateJson)).Returns(reportState);
 
             WalkArgs capturedWalkArgs = null;
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
-                .Callback<WalkArgs, Action<InsightEvent, IEventLogWalkerStatus>>((args, _) => capturedWalkArgs = args)
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<WalkedEvent, IEventLogWalkerStatus>>()))
+                .Callback<WalkArgs, Action<WalkedEvent, IEventLogWalkerStatus>>((args, _) => capturedWalkArgs = args)
                 .ReturnsAsync(new TestEventLogWalkerStatus());
 
             await ClassUnderTest.GenerateAsync(reportPeriodStartInclusive, reportPeriodEndExclusive);
@@ -135,7 +135,7 @@ namespace ExampleReports.UnitTests
                 .Callback<AccountUserCountsReportState>(reportState => capturedAccountUserCountsReportState = reportState)
                 .Returns(stateJson);
 
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs>(), IsAny<Action<WalkedEvent, IEventLogWalkerStatus>>()))
                 .ReturnsAsync(statusMock.Object);
 
             await ClassUnderTest.GenerateAsync(reportPeriodStartInclusive, reportPeriodEndExclusive);
@@ -151,186 +151,186 @@ namespace ExampleReports.UnitTests
         [Test]
         public void When_processing_multiple_events_of_the_same_type_for_distinct_accounts()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 AccountId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
-                EventType = insightEvent1.EventType,
+                EventType = insightEvent1.Event.EventType,
                 AccountId = NewGuid()
-            };
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventAccountCounts, Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType], Has.Count.EqualTo(2));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType],
-                Contains.Item(insightEvent1.AccountId));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType],
-                Contains.Item(insightEvent2.AccountId));
+            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(2));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType],
+                Contains.Item(insightEvent1.Event.AccountId));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType],
+                Contains.Item(insightEvent2.Event.AccountId));
         }
 
         [Test]
         public void When_processing_multiple_events_of_the_same_type_for_the_same_account()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 AccountId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
-                EventType = insightEvent1.EventType,
-                AccountId = insightEvent1.AccountId
-            };
+                EventType = insightEvent1.Event.EventType,
+                AccountId = insightEvent1.Event.AccountId
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventAccountCounts, Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType],
-                Contains.Item(insightEvent1.AccountId));
+            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType],
+                Contains.Item(insightEvent1.Event.AccountId));
         }
 
         [Test]
         public void When_processing_multiple_events_of_distinct_types_for_distinct_accounts()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 AccountId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 AccountId = NewGuid()
-            };
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventAccountCounts, Has.Count.EqualTo(2));
-            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.EventType],
-                Contains.Item(insightEvent1.AccountId));
-            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent2.EventType));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent2.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent2.EventType],
-                Contains.Item(insightEvent2.AccountId));
+            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent1.Event.EventType],
+                Contains.Item(insightEvent1.Event.AccountId));
+            Assert.That(ClassUnderTest.EventAccountCounts, Contains.Key(insightEvent2.Event.EventType));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent2.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventAccountCounts[insightEvent2.Event.EventType],
+                Contains.Item(insightEvent2.Event.AccountId));
         }
 
         [Test]
         public void When_processing_multiple_events_of_the_same_type_for_distinct_user()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
-                EventType = insightEvent1.EventType,
+                EventType = insightEvent1.Event.EventType,
                 UserId = NewGuid()
-            };
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventUserCounts, Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Has.Count.EqualTo(2));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Contains.Item(insightEvent1.UserId));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Contains.Item(insightEvent2.UserId));
+            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(2));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Contains.Item(insightEvent1.Event.UserId));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Contains.Item(insightEvent2.Event.UserId));
         }
 
         [Test]
         public void When_processing_multiple_events_of_the_same_type_for_the_same_user()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
-                EventType = insightEvent1.EventType,
-                UserId = insightEvent1.UserId
-            };
+                EventType = insightEvent1.Event.EventType,
+                UserId = insightEvent1.Event.UserId
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventUserCounts, Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Contains.Item(insightEvent1.UserId));
+            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Contains.Item(insightEvent1.Event.UserId));
         }
 
         [Test]
         public void When_processing_multiple_events_of_distinct_types_for_distinct_users()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
             var status1 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent1,status1);
 
-            var insightEvent2 = new InsightEvent
+            var insightEvent2 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
             var status2 = new TestEventLogWalkerStatus();
 
             ClassUnderTest.ProcessEvent(insightEvent2,status2);
 
             Assert.That(ClassUnderTest.EventUserCounts, Has.Count.EqualTo(2));
-            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.EventType));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.EventType], Contains.Item(insightEvent1.UserId));
-            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent2.EventType));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent2.EventType], Has.Count.EqualTo(1));
-            Assert.That(ClassUnderTest.EventUserCounts[insightEvent2.EventType], Contains.Item(insightEvent2.UserId));
+            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent1.Event.EventType));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent1.Event.EventType], Contains.Item(insightEvent1.Event.UserId));
+            Assert.That(ClassUnderTest.EventUserCounts, Contains.Key(insightEvent2.Event.EventType));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent2.Event.EventType], Has.Count.EqualTo(1));
+            Assert.That(ClassUnderTest.EventUserCounts[insightEvent2.Event.EventType], Contains.Item(insightEvent2.Event.UserId));
         }
 
         [Test]
         public void When_processing_and_persist_state_should_occur()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
             var resumeToken = RandomString();
             var stateJson = RandomString();
 
@@ -355,11 +355,11 @@ namespace ExampleReports.UnitTests
         [Test]
         public void When_processing_state_should_not_be_persisted_for_each_event()
         {
-            var insightEvent1 = new InsightEvent
+            var insightEvent1 = new WalkedEvent{ Event = new InsightEvent
             {
                 EventType = RandomString(),
                 UserId = NewGuid()
-            };
+            }};
 
             var statusMock = GetMock<IEventLogWalkerStatus>();
             statusMock.SetupGet(x => x.TotalEventsProcessed).Returns(499);

--- a/ExampleReports.UnitTests/AccountUserCountsReportTests.cs
+++ b/ExampleReports.UnitTests/AccountUserCountsReportTests.cs
@@ -55,13 +55,11 @@ namespace ExampleReports.UnitTests
                     capturedRecords = records;
                 });
 
-            IPager<InsightEvent> capturedPager = null;
-            WalkArgs capturedWalkArgs = null;
+            WalkArgs<InsightEvent> capturedWalkArgs = null;
             Action<InsightEvent, IEventLogWalkerStatus> capturedFunc = null;
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<IPager<InsightEvent>>(), IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
-                .Callback<IPager<InsightEvent>, WalkArgs, Action<InsightEvent, IEventLogWalkerStatus>>((pager, args, func) =>
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs<InsightEvent>>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
+                .Callback<WalkArgs<InsightEvent>, Action<InsightEvent, IEventLogWalkerStatus>>((args, func) =>
                 {
-                    capturedPager = pager;
                     capturedWalkArgs = args;
                     capturedFunc = func;
                 })
@@ -73,7 +71,7 @@ namespace ExampleReports.UnitTests
 
             GetMock<IFileSystem>().Verify(x => x.DeleteFile(AccountUserCountsReport.StateFilePath));
 
-            Assert.That(capturedPager, Is.EqualTo(expectedPager));
+            Assert.That(capturedWalkArgs.Pager, Is.EqualTo(expectedPager));
             Assert.That(capturedWalkArgs.StartInclusive, Is.EqualTo(reportPeriodStartInclusive));
             Assert.That(capturedWalkArgs.EndExclusive, Is.EqualTo(reportPeriodEndExclusive));
             Assert.That(capturedWalkArgs.ResumeToken, Is.Null);
@@ -107,9 +105,9 @@ namespace ExampleReports.UnitTests
             GetMock<IFileSystem>().Setup(x => x.ReadFile(AccountUserCountsReport.StateFilePath)).Returns(stateJson);
             GetMock<IJsonSerializer>().Setup(x => x.Deserialize<AccountUserCountsReportState>(stateJson)).Returns(reportState);
 
-            WalkArgs capturedWalkArgs = null;
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<IPager<InsightEvent>>(), IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
-                .Callback<IPager<InsightEvent>, WalkArgs, Action<InsightEvent, IEventLogWalkerStatus>>((_x, args, _y) => capturedWalkArgs = args)
+            WalkArgs<InsightEvent> capturedWalkArgs = null;
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs<InsightEvent>>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
+                .Callback<WalkArgs<InsightEvent>, Action<InsightEvent, IEventLogWalkerStatus>>((args, _) => capturedWalkArgs = args)
                 .ReturnsAsync(new TestEventLogWalkerStatus());
 
             await ClassUnderTest.GenerateAsync(reportPeriodStartInclusive, reportPeriodEndExclusive);
@@ -140,7 +138,7 @@ namespace ExampleReports.UnitTests
                 .Callback<AccountUserCountsReportState>(reportState => capturedAccountUserCountsReportState = reportState)
                 .Returns(stateJson);
 
-            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<IPager<InsightEvent>>(), IsAny<WalkArgs>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
+            GetMock<IEventLogWalker>().Setup(x => x.WalkAsync(IsAny<WalkArgs<InsightEvent>>(), IsAny<Action<InsightEvent, IEventLogWalkerStatus>>()))
                 .ReturnsAsync(statusMock.Object);
 
             await ClassUnderTest.GenerateAsync(reportPeriodStartInclusive, reportPeriodEndExclusive);

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -21,15 +21,17 @@ namespace ExampleReports
         private readonly ICsvWriter csvWriter;
         private readonly IJsonSerializer jsonSerializer;
         private readonly IFileSystem fileSystem;
+        private readonly IPager<InsightEvent> pager;
         private readonly TimeTracker eventTimeTracker;
 
         public AccountUserCountsReport(IEventLogWalker eventLogWalker, ICsvWriter csvWriter,
-            IJsonSerializer jsonSerializer, IFileSystem fileSystem)
+            IJsonSerializer jsonSerializer, IFileSystem fileSystem, IPager<InsightEvent> pager)
         {
             this.eventLogWalker = eventLogWalker;
             this.csvWriter = csvWriter;
             this.jsonSerializer = jsonSerializer;
             this.fileSystem = fileSystem;
+            this.pager = pager;
 
             eventTimeTracker = new TimeTracker(1);
         }
@@ -53,7 +55,7 @@ args =>
             var resumeToken = LoadState();
 
             //  NOTE: See ExampleReports.Configuration.DependencyInjectionConfig to understand the package dependency needs
-            var status = await eventLogWalker.WalkAsync<InsightEvent>(
+            var status = await eventLogWalker.WalkAsync(pager,
                 new WalkArgs
                 {
                     StartInclusive = reportPeriodStartInclusive,

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -95,7 +95,7 @@ args =>
             }).ToList();
         }
 
-        public void ProcessEvent(InsightEvent insightEvent, IEventLogWalkerStatus status)
+        public void ProcessEvent(WalkedEvent walkedEvent, IEventLogWalkerStatus status)
         {
             if (status.PageStatus == PageStatus.Start)
             {
@@ -103,31 +103,31 @@ args =>
                 eventTimeTracker.ItemCompleted($"Page number: {status.PageNumber}. TotalProcessedEvents: {status.TotalEventsProcessed}. ");
             }
 
-            StoreDistinctAccounts(insightEvent);
-            StoreDistinctUsers(insightEvent);
+            StoreDistinctAccounts(walkedEvent);
+            StoreDistinctUsers(walkedEvent);
         }
 
-        private void StoreDistinctAccounts(InsightEvent insightEvent)
+        private void StoreDistinctAccounts(WalkedEvent walkedEvent)
         {
-            if (EventAccountCounts.ContainsKey(insightEvent.EventType))
+            if (EventAccountCounts.ContainsKey(walkedEvent.Event.EventType))
             {
-                EventAccountCounts[insightEvent.EventType].Add(insightEvent.AccountId);
+                EventAccountCounts[walkedEvent.Event.EventType].Add(walkedEvent.Event.AccountId);
             }
             else
             {
-                EventAccountCounts[insightEvent.EventType] = new HashSet<Guid> {insightEvent.AccountId};
+                EventAccountCounts[walkedEvent.Event.EventType] = new HashSet<Guid> {walkedEvent.Event.AccountId};
             }
         }
 
-        private void StoreDistinctUsers(InsightEvent insightEvent)
+        private void StoreDistinctUsers(WalkedEvent walkedEvent)
         {
-            if (EventUserCounts.ContainsKey(insightEvent.EventType))
+            if (EventUserCounts.ContainsKey(walkedEvent.Event.EventType))
             {
-                EventUserCounts[insightEvent.EventType].Add(insightEvent.UserId);
+                EventUserCounts[walkedEvent.Event.EventType].Add(walkedEvent.Event.UserId);
             }
             else
             {
-                EventUserCounts[insightEvent.EventType] = new HashSet<Guid> {insightEvent.UserId};
+                EventUserCounts[walkedEvent.Event.EventType] = new HashSet<Guid> {walkedEvent.Event.UserId};
             }
         }
 

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -55,10 +55,9 @@ args =>
             var resumeToken = LoadState();
 
             //  NOTE: See ExampleReports.Configuration.DependencyInjectionConfig to understand the package dependency needs
-            var status = await eventLogWalker.WalkAsync(
-                new WalkArgs<InsightEvent>
+            var status = await eventLogWalker.WalkAsync(pager,
+                new WalkArgs
                 {
-                    Pager = pager,
                     StartInclusive = reportPeriodStartInclusive,
                     EndExclusive = reportPeriodEndExclusive,
                     ResumeToken = resumeToken

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Emmersion.EventLogWalker;
@@ -77,7 +78,7 @@ args =>
                 $"{nameof(EventCounts.EventType)},{nameof(EventCounts.DistinctAccounts)},{nameof(EventCounts.DistinctUsers)}";
             csvWriter.WriteAll(fileName, headerRow, eventCounts);
 
-            Console.WriteLine($"Wrote to: {fileName}");
+            Console.WriteLine($"Wrote to: {Directory.GetCurrentDirectory()}\\{fileName}");
 
             fileSystem.DeleteFile(StateFilePath);
         }

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -55,9 +55,10 @@ args =>
             var resumeToken = LoadState();
 
             //  NOTE: See ExampleReports.Configuration.DependencyInjectionConfig to understand the package dependency needs
-            var status = await eventLogWalker.WalkAsync(pager,
-                new WalkArgs
+            var status = await eventLogWalker.WalkAsync(
+                new WalkArgs<InsightEvent>
                 {
+                    Pager = pager,
                     StartInclusive = reportPeriodStartInclusive,
                     EndExclusive = reportPeriodEndExclusive,
                     ResumeToken = resumeToken

--- a/ExampleReports/AccountUserCountsReport.cs
+++ b/ExampleReports/AccountUserCountsReport.cs
@@ -53,7 +53,7 @@ args =>
             var resumeToken = LoadState();
 
             //  NOTE: See ExampleReports.Configuration.DependencyInjectionConfig to understand the package dependency needs
-            var status = await eventLogWalker.WalkAsync(
+            var status = await eventLogWalker.WalkAsync<InsightEvent>(
                 new WalkArgs
                 {
                     StartInclusive = reportPeriodStartInclusive,
@@ -95,7 +95,7 @@ args =>
             }).ToList();
         }
 
-        public void ProcessEvent(WalkedEvent walkedEvent, IEventLogWalkerStatus status)
+        public void ProcessEvent(InsightEvent insightEvent, IEventLogWalkerStatus status)
         {
             if (status.PageStatus == PageStatus.Start)
             {
@@ -103,31 +103,31 @@ args =>
                 eventTimeTracker.ItemCompleted($"Page number: {status.PageNumber}. TotalProcessedEvents: {status.TotalEventsProcessed}. ");
             }
 
-            StoreDistinctAccounts(walkedEvent);
-            StoreDistinctUsers(walkedEvent);
+            StoreDistinctAccounts(insightEvent);
+            StoreDistinctUsers(insightEvent);
         }
 
-        private void StoreDistinctAccounts(WalkedEvent walkedEvent)
+        private void StoreDistinctAccounts(InsightEvent insightEvent)
         {
-            if (EventAccountCounts.ContainsKey(walkedEvent.Event.EventType))
+            if (EventAccountCounts.ContainsKey(insightEvent.EventType))
             {
-                EventAccountCounts[walkedEvent.Event.EventType].Add(walkedEvent.Event.AccountId);
+                EventAccountCounts[insightEvent.EventType].Add(insightEvent.AccountId);
             }
             else
             {
-                EventAccountCounts[walkedEvent.Event.EventType] = new HashSet<Guid> {walkedEvent.Event.AccountId};
+                EventAccountCounts[insightEvent.EventType] = new HashSet<Guid> {insightEvent.AccountId};
             }
         }
 
-        private void StoreDistinctUsers(WalkedEvent walkedEvent)
+        private void StoreDistinctUsers(InsightEvent insightEvent)
         {
-            if (EventUserCounts.ContainsKey(walkedEvent.Event.EventType))
+            if (EventUserCounts.ContainsKey(insightEvent.EventType))
             {
-                EventUserCounts[walkedEvent.Event.EventType].Add(walkedEvent.Event.UserId);
+                EventUserCounts[insightEvent.EventType].Add(insightEvent.UserId);
             }
             else
             {
-                EventUserCounts[walkedEvent.Event.EventType] = new HashSet<Guid> {walkedEvent.Event.UserId};
+                EventUserCounts[insightEvent.EventType] = new HashSet<Guid> {insightEvent.UserId};
             }
         }
 

--- a/ExampleReports/Program.cs
+++ b/ExampleReports/Program.cs
@@ -20,8 +20,8 @@ namespace ExampleReports
         {
             var report = services.GetRequiredService<IAccountUserCountsReport>();
 
-            var startInclusive = DateTimeOffset.Parse("2021-06-01");
-            var maxEndExclusive = DateTimeOffset.Parse("2021-07-01");
+            var startInclusive = DateTimeOffset.Parse("2020-07-01");
+            var maxEndExclusive = DateTimeOffset.Parse("2020-07-02");
 
             await report.GenerateAsync(startInclusive, maxEndExclusive);
         }

--- a/ExampleReports/Program.cs
+++ b/ExampleReports/Program.cs
@@ -11,9 +11,9 @@ namespace ExampleReports
         {
             var services = ConfigureServices();
 
+            await ComplexReport(services);
             //await SimpleReport(services);
             //await ResumeValidationReport(services);
-            await ComplexReport(services);
         }
 
         private static async Task ComplexReport(ServiceProvider services)

--- a/ExampleReports/Program.cs
+++ b/ExampleReports/Program.cs
@@ -11,9 +11,9 @@ namespace ExampleReports
         {
             var services = ConfigureServices();
 
-            await ComplexReport(services);
             //await SimpleReport(services);
             //await ResumeValidationReport(services);
+            await ComplexReport(services);
         }
 
         private static async Task ComplexReport(ServiceProvider services)

--- a/ExampleReports/ResumeValidationReport.cs
+++ b/ExampleReports/ResumeValidationReport.cs
@@ -48,12 +48,12 @@ namespace ExampleReports
                     }
 
 
-                    if (eventIds.Contains(insightEvent.Id))
+                    if (eventIds.Contains(insightEvent.Event.Id))
                     {
-                        throw new Exception($"The id {insightEvent.Id} was processed twice.");
+                        throw new Exception($"The id {insightEvent.Event.Id} was processed twice.");
                     }
 
-                    eventIds.Add(insightEvent.Id);
+                    eventIds.Add(insightEvent.Event.Id);
                 });
 
             if (finalStatus.Exception != null)

--- a/ExampleReports/ResumeValidationReport.cs
+++ b/ExampleReports/ResumeValidationReport.cs
@@ -35,7 +35,7 @@ namespace ExampleReports
             var state = LoadState();
             var eventIds = state.EventIds;
 
-            var finalStatus = await walker.WalkAsync(new WalkArgs {ResumeToken = state.WalkerResumeToken},
+            var finalStatus = await walker.WalkAsync<InsightEvent>(new WalkArgs {ResumeToken = state.WalkerResumeToken},
                 (insightEvent, status) =>
                 {
                     if (status.PageStatus == PageStatus.Start)
@@ -48,12 +48,12 @@ namespace ExampleReports
                     }
 
 
-                    if (eventIds.Contains(insightEvent.Event.Id))
+                    if (eventIds.Contains(insightEvent.Id))
                     {
-                        throw new Exception($"The id {insightEvent.Event.Id} was processed twice.");
+                        throw new Exception($"The id {insightEvent.Id} was processed twice.");
                     }
 
-                    eventIds.Add(insightEvent.Event.Id);
+                    eventIds.Add(insightEvent.Id);
                 });
 
             if (finalStatus.Exception != null)

--- a/ExampleReports/ResumeValidationReport.cs
+++ b/ExampleReports/ResumeValidationReport.cs
@@ -39,7 +39,7 @@ namespace ExampleReports
             var state = LoadState();
             var eventIds = state.EventIds;
 
-            var finalStatus = await walker.WalkAsync(new WalkArgs<InsightEvent> {Pager = pager, ResumeToken = state.WalkerResumeToken},
+            var finalStatus = await walker.WalkAsync(pager, new WalkArgs {ResumeToken = state.WalkerResumeToken},
                 (insightEvent, status) =>
                 {
                     if (status.PageStatus == PageStatus.Start)

--- a/ExampleReports/ResumeValidationReport.cs
+++ b/ExampleReports/ResumeValidationReport.cs
@@ -19,23 +19,27 @@ namespace ExampleReports
         private readonly IEventLogWalker walker;
         private readonly IJsonSerializer jsonSerializer;
         private readonly IFileSystem fileSystem;
+        private readonly IPager<InsightEvent> pager;
         private readonly TimeTracker eventTimeTracker;
 
-        public ResumeValidationReport(IEventLogWalker walker, IJsonSerializer jsonSerializer, IFileSystem fileSystem)
+        public ResumeValidationReport(IEventLogWalker walker, IJsonSerializer jsonSerializer, IFileSystem fileSystem, IPager<InsightEvent> pager)
         {
             this.walker = walker;
             this.jsonSerializer = jsonSerializer;
             this.fileSystem = fileSystem;
+            this.pager = pager;
 
             eventTimeTracker = new TimeTracker(1);
         }
 
         public async Task GenerateAsync()
         {
+            Console.WriteLine("WARNING: This report runs across the entire event log. This report is for example/test only. Recommend abort after a few events are processed.");
+
             var state = LoadState();
             var eventIds = state.EventIds;
 
-            var finalStatus = await walker.WalkAsync<InsightEvent>(new WalkArgs {ResumeToken = state.WalkerResumeToken},
+            var finalStatus = await walker.WalkAsync(pager, new WalkArgs {ResumeToken = state.WalkerResumeToken},
                 (insightEvent, status) =>
                 {
                     if (status.PageStatus == PageStatus.Start)

--- a/ExampleReports/ResumeValidationReport.cs
+++ b/ExampleReports/ResumeValidationReport.cs
@@ -39,7 +39,7 @@ namespace ExampleReports
             var state = LoadState();
             var eventIds = state.EventIds;
 
-            var finalStatus = await walker.WalkAsync(pager, new WalkArgs {ResumeToken = state.WalkerResumeToken},
+            var finalStatus = await walker.WalkAsync(new WalkArgs<InsightEvent> {Pager = pager, ResumeToken = state.WalkerResumeToken},
                 (insightEvent, status) =>
                 {
                     if (status.PageStatus == PageStatus.Start)

--- a/ExampleReports/SimpleReport.cs
+++ b/ExampleReports/SimpleReport.cs
@@ -13,18 +13,29 @@ namespace ExampleReports
     public class SimpleReport : ISimpleReport
     {
         private readonly IEventLogWalker walker;
+        private readonly IPager<InsightEvent> pager;
 
-        public SimpleReport(IEventLogWalker walker)
+        public SimpleReport(IEventLogWalker walker, IPager<InsightEvent> pager)
         {
             this.walker = walker;
+            this.pager = pager;
         }
 
         public async Task GenerateAsync()
         {
+            Console.WriteLine("WARNING: This report runs across the entire event log. This report is for example only. Recommend abort after a few events are processed.");
+
             var eventCounts = new Dictionary<string, int>();
-            
-            var finalStatus = await walker.WalkAsync<InsightEvent>(new WalkArgs(), (insightEvent, status) =>
+
+            var i = 0;
+            var finalStatus = await walker.WalkAsync(pager, new WalkArgs(), (insightEvent, status) =>
             {
+                i++;
+                if (i % 1000 == 0)
+                {
+                    Console.WriteLine($"Processed {i} events");
+                }
+
                 if (eventCounts.ContainsKey(insightEvent.EventType))
                 {
                     eventCounts[insightEvent.EventType] += 1;

--- a/ExampleReports/SimpleReport.cs
+++ b/ExampleReports/SimpleReport.cs
@@ -28,7 +28,7 @@ namespace ExampleReports
             var eventCounts = new Dictionary<string, int>();
 
             var i = 0;
-            var finalStatus = await walker.WalkAsync(pager, new WalkArgs(), (insightEvent, status) =>
+            var finalStatus = await walker.WalkAsync(new WalkArgs<InsightEvent>{ Pager = pager }, (insightEvent, status) =>
             {
                 i++;
                 if (i % 1000 == 0)

--- a/ExampleReports/SimpleReport.cs
+++ b/ExampleReports/SimpleReport.cs
@@ -25,13 +25,13 @@ namespace ExampleReports
             
             var finalStatus = await walker.WalkAsync(new WalkArgs(), (insightEvent, status) =>
             {
-                if (eventCounts.ContainsKey(insightEvent.EventType))
+                if (eventCounts.ContainsKey(insightEvent.Event.EventType))
                 {
-                    eventCounts[insightEvent.EventType] += 1;
+                    eventCounts[insightEvent.Event.EventType] += 1;
                 }
                 else
                 {
-                    eventCounts[insightEvent.EventType] = 1;
+                    eventCounts[insightEvent.Event.EventType] = 1;
                 }
             });
             

--- a/ExampleReports/SimpleReport.cs
+++ b/ExampleReports/SimpleReport.cs
@@ -28,7 +28,7 @@ namespace ExampleReports
             var eventCounts = new Dictionary<string, int>();
 
             var i = 0;
-            var finalStatus = await walker.WalkAsync(new WalkArgs<InsightEvent>{ Pager = pager }, (insightEvent, status) =>
+            var finalStatus = await walker.WalkAsync(pager, new WalkArgs(), (insightEvent, status) =>
             {
                 i++;
                 if (i % 1000 == 0)

--- a/ExampleReports/SimpleReport.cs
+++ b/ExampleReports/SimpleReport.cs
@@ -23,15 +23,15 @@ namespace ExampleReports
         {
             var eventCounts = new Dictionary<string, int>();
             
-            var finalStatus = await walker.WalkAsync(new WalkArgs(), (insightEvent, status) =>
+            var finalStatus = await walker.WalkAsync<InsightEvent>(new WalkArgs(), (insightEvent, status) =>
             {
-                if (eventCounts.ContainsKey(insightEvent.Event.EventType))
+                if (eventCounts.ContainsKey(insightEvent.EventType))
                 {
-                    eventCounts[insightEvent.Event.EventType] += 1;
+                    eventCounts[insightEvent.EventType] += 1;
                 }
                 else
                 {
-                    eventCounts[insightEvent.Event.EventType] = 1;
+                    eventCounts[insightEvent.EventType] = 1;
                 }
             });
             

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
 pr: none
 pool:
   vmImage: 'ubuntu-latest'
-name: 1.0$(Rev:.r)
+name: 2.0$(Rev:.r)
 variables:
   - group: 'NuGetPublishing'
 steps:


### PR DESCRIPTION
Premise: I was going to just cut myself a build with a hook up to the `EnterpriseApiEventLog`. Then I realized that I could potentially ~easily~ make the library extendable allowing for custom paging and arbitrary events. *I still think this is easier than other options and better for long term use cases that I know exist today.

~I didn't want to break existing usages, so I want to leave the default implementation as the Emmersion Insights EventLog.~ There is a significant amount of work to extract Insights EventLogWalker as a default implementation so leaving for now. However, I think over time we could extract that too.

`IPager` is the name we landed on for now.

When processing an event only the target event type will be exposed. ~This simplifies accessing the data and hides the cast internally. The cast is safe enough, though there is nothing at compile time to guarantee the IPager in use is providing pages of the correct event type.~ IPager is now generic and compile time safety now glues the EventLogWalker to the IPager impl.